### PR TITLE
Add new MaskManager: WorldguardFlag

### DIFF
--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
@@ -467,6 +467,7 @@ public class FaweBukkit implements IFawe, Listener {
         if ((worldguardPlugin != null) && worldguardPlugin.isEnabled()) {
             try {
                 managers.add(new Worldguard(worldguardPlugin, this));
+                managers.add(new WorldguardFlag(worldguardPlugin, this));
                 Fawe.debug("Plugin 'WorldGuard' found. Using it now.");
             } catch (final Throwable e) {
                 MainUtil.handleError(e);

--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/regions/WorldguardFlag.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/regions/WorldguardFlag.java
@@ -1,0 +1,112 @@
+package com.boydti.fawe.bukkit.regions;
+
+import com.boydti.fawe.bukkit.FaweBukkit;
+import com.boydti.fawe.bukkit.filter.WorldGuardFilter;
+import com.boydti.fawe.object.FawePlayer;
+import com.boydti.fawe.regions.FaweMask;
+import com.boydti.fawe.regions.general.RegionFilter;
+import com.sk89q.worldedit.Vector;
+import com.sk89q.worldedit.regions.AbstractRegion;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flags;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.*;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Map;
+
+public class WorldguardFlag extends BukkitMaskManager implements Listener {
+    private WorldGuardPlugin worldguard;
+    FaweBukkit plugin;
+
+    public WorldguardFlag(final Plugin p2, final FaweBukkit p3) {
+        super("worldguardflag");
+        this.worldguard = (WorldGuardPlugin) p2; // this.getWorldGuard();
+        this.plugin = p3;
+    }
+
+    @Override
+    public FaweMask getMask(FawePlayer<Player> fp, MaskType type) {
+        final Player player = fp.parent;
+        final LocalPlayer localplayer = this.worldguard.wrapPlayer(player);
+        final RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        final RegionManager manager = container.get(fp.getWorld());
+
+        return new FaweMask(new ManagerRegion(manager, localplayer), null) {
+            @Override
+            public boolean isValid(FawePlayer player, MaskType type) {
+                // We rely on the region mask instead of this
+                return true;
+            }
+        };
+    }
+
+    @Override
+    public RegionFilter getFilter(String world) {
+        return new WorldGuardFilter(Bukkit.getWorld(world));
+    }
+
+    /***
+     * ManagerRegion wraps a RegionManager and will provide results based upon the regions enclosed
+     */
+    private static class ManagerRegion extends AbstractRegion {
+        private final RegionManager manager;
+        private final LocalPlayer localplayer;
+
+        ManagerRegion(RegionManager manager, LocalPlayer localplayer) {
+            super(null);
+            this.manager = manager;
+            this.localplayer = localplayer;
+        }
+
+        @Override
+        public Vector getMinimumPoint() {
+            Vector point = null;
+            for (Map.Entry<String, ProtectedRegion> entry : manager.getRegions().entrySet()) {
+                Vector p = entry.getValue().getMinimumPoint();
+                if (point == null) {
+                    point = p;
+                    continue;
+                }
+                point = Vector.getMinimum(point, p);
+            }
+            return point;
+        }
+
+        @Override
+        public Vector getMaximumPoint() {
+            Vector point = null;
+            for (Map.Entry<String, ProtectedRegion> entry : manager.getRegions().entrySet()) {
+                Vector p = entry.getValue().getMaximumPoint();
+                if (point == null) {
+                    point = p;
+                    continue;
+                }
+                point = Vector.getMaximum(point, p);
+            }
+            return point;
+        }
+
+        @Override
+        public void expand(Vector... changes) {
+            throw new UnsupportedOperationException("Region is immutable");
+        }
+
+        @Override
+        public void contract(Vector... changes) {
+            throw new UnsupportedOperationException("Region is immutable");
+        }
+
+        @Override
+        public boolean contains(Vector position) {
+            // Make sure that all these flags are not denied. Denies override allows. WorldGuardExtraFlags can add Flags.WORLDEDIT
+            return  manager.getApplicableRegions(position).testState(localplayer, Flags.BUILD, Flags.BLOCK_PLACE, Flags.BLOCK_BREAK);
+        }
+
+    }
+}


### PR DESCRIPTION
# Current
With respect to the original design I've never been totally satisfied with how FAWE behaves with  WorldGuard for the following reasons:

1. It uses its own method of determining if someone has access to use editor commands in a region. This can go directly against the Worldguard settings in sometimes odd ways where builders can mistakenly be able to use commands in restricted regions or cannot perform operations in regions they should.

2. Oddities depending on the player location. A player may be unable to use a command when standing in the wrong spot. 

3. Oddities due to mask caching. For example, pasting a large clipboard that spans multiple regions may only allow the contents in the region the player is standing in, even though the next region is also allowed. If the player then moves to that next region it is now cached and will properly paste over them all.

4. Does not support inheritance. For example a large region that denies building with a smaller higher priority region that permits it.

I realise many of these are or were due to performance reasons.

# Proposed
This PR add's a new mask manager 'WorldGuardFlag'.
1. It attempts to make use of WorldGuard state flags when determining if a mask is valid. We check if (BUILD, BLOCK_BREAK, BLOCK_PLACE) return true.

2. It attempts to remain backwards compatible by providing a new mask manager. The user must have 'fawe.worldguardflag' permissions to trigger this (and probably removed fawe.worldguard permissions). I'm not 100% sure if a deny on one mask manager will then fall back to the next one in the chain.

3. IMHO FaweRegionExtent should probably be edited to allow non-destructive operations to allow a user to copy items outside of regions they are allowed to paste in or rely on some additional permission but I've not changed that here for backwards compatibility.

4. The player's location is no longer that important apart from determining the World. It is the mask that defines operations.

# Potential Issues
1. The height in EditSession is checked via an extent only if regions are not used. Perhaps it needs to be a fall-through extent instead that denies if its outside range but falls through to the next extent otherwise (which will require a final extent to actually allow). I noticed pasting a LARGE schematic that went above the map height caused an exception but am not sure if the Mask is the correct place to check this.

2. I'm not sure how much this will affect performance, hence it's optional via a permission.

3. I'm not sure how non WE commands are affected.

4. I'd like to add a PR to WorldGuardExtraFlags plugin that adds the WORLDEDIT flag as well for FAWE. This would entirely deprecate the need for Owners/Members support in FAWE.
