### PR TITLE
Bypass warning invalid block registered for __RESERVED__

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/DefaultBlockParser.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/extension/factory/DefaultBlockParser.java
@@ -259,7 +259,7 @@ public class DefaultBlockParser extends InputParser<BlockStateHolder> {
         if (context.isRestricted()) {
             Actor actor = context.requireActor();
             if (actor != null) {
-                if (!actor.hasPermission("worldedit.anyblock") && worldEdit.getConfiguration().disallowedBlocks.contains(blockType.getId())) {
+                if (!actor.hasPermission("worldedit.anyblock") && worldEdit.getConfiguration().disallowedBlocks.contains(blockType)) {
                     throw new DisallowedUsageException("You are not allowed to use '" + input + "'");
                 }
                 if (nbt != null) {

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypes.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/world/block/BlockTypes.java
@@ -1015,7 +1015,7 @@ public enum BlockTypes implements BlockType {
             for (BlockTypes type : oldValues) {
                 if (!blockMap.containsKey(type.getId())) {
                     type.init(type.getId(), 0, new ArrayList<>());
-                    Fawe.debug("Invalid block registered " + type.getId());
+                    if (type != __RESERVED__) Fawe.debug("Invalid block registered " + type.getId());
                     size++;
                 }
                 if (type != __RESERVED__) {


### PR DESCRIPTION
Some server owners brought to light the warning message for the __RESERVED__ BlockType registration being shown in console, and this commit aims to remove that from occuring.