### PR TITLE
Check for AsyncTabCompleteEvent class before attempting to create listener

### DIFF
--- a/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
+++ b/worldedit-bukkit/src/main/java/com/boydti/fawe/bukkit/FaweBukkit.java
@@ -125,6 +125,7 @@ public class FaweBukkit implements IFawe, Listener {
                 }
 
                 try {
+                	Class.forName("com.destroystokyo.paper.event.server.AsyncTabCompleteEvent");
                     new AsyncTabCompleteListener(WorldEditPlugin.getInstance());
                 } catch (Throwable ignore)
                 {


### PR DESCRIPTION
Prevents failed event registration error message from displaying.